### PR TITLE
Catch not found exception when deleting a share

### DIFF
--- a/manila/share/drivers/scality/driver.py
+++ b/manila/share/drivers/scality/driver.py
@@ -22,6 +22,7 @@ from manila import exception
 from manila.i18n import _
 from manila.i18n import _LE
 from manila.i18n import _LI
+from manila.i18n import _LW
 from manila.share import driver
 from manila import utils
 
@@ -179,7 +180,10 @@ class ScalityShareDriver(driver.ShareDriver):
         self._get_helper(share).deny_access(share, access)
 
     def delete_share(self, context, share, share_server=None):
-        self._get_helper(share).delete_share(share)
+        try:
+            self._get_helper(share).delete_share(share)
+        except exception.InvalidShare as exc:
+            LOG.warning(_LW("Delete share failed with : %s"), exc)
 
     def create_share(self, context, share, share_server=None):
         return self._get_helper(share).create_share(share)

--- a/manila/tests/share/drivers/scality/test_scality.py
+++ b/manila/tests/share/drivers/scality/test_scality.py
@@ -207,6 +207,17 @@ class ScalityShareDriverTestCase(test.TestCase):
         self.assertRaises(exception.ManilaException, drv.get_share_stats,
                           refresh=True)
 
+    def test_delete_share_when_share_not_found(self):
+        drv = driver.ScalityShareDriver(configuration=self.cfg)
+        share = fake_share.fake_share()
+        exc = exception.InvalidShare(reason=u"Unicode\u1234")
+        with mock.patch.object(drv, '_get_helper') as mock_get_helper:
+            mock_get_helper.return_value.delete_share.side_effect = exc
+            # assert that the exception has been caught.
+            self.assertIsNone(drv.delete_share(self.context, share))
+        mock_get_helper.return_value.delete_share.assert_called_once_with(
+            share)
+
 
 class NASHelperTestCase(test.TestCase):
 


### PR DESCRIPTION
If there was an error when the share was created, the share might not
have been created on SOFS. Thus when deleting the share we should catch
the `NotFound` exception and just log a warning. Otherwise you can't
really delete a share that was not properly created.
